### PR TITLE
fix: prevent sending daily summary email when there are no changes

### DIFF
--- a/.changeset/fix-daily-summary-email-zero-changes.md
+++ b/.changeset/fix-daily-summary-email-zero-changes.md
@@ -1,0 +1,5 @@
+---
+'gcal-sync': patch
+---
+
+fix: prevent sending daily summary email when there are no changes

--- a/src/methods/handle_session_data.ts
+++ b/src/methods/handle_session_data.ts
@@ -141,9 +141,12 @@ function sendSessionEmails(extendedConfigs: TExtendedConfigs, sessionData: TExte
   const isNowTimeAfterDailyEmails = isCurrentTimeAfter(extendedConfigs.configs.settings.per_day_emails.time_to_send, extendedConfigs.timezone_offset);
 
   const alreadySentTodaySummaryEmail = extendedConfigs.today_date === getGASProperty(GAS_PROPERTIES_ENUM.last_daily_email_sent_date);
-  if (isNowTimeAfterDailyEmails && extendedConfigs.configs.settings.per_day_emails.email_daily_summary && !alreadySentTodaySummaryEmail) {
+  const todayStats = getTodayStats();
+  const totalTodayChanges = todayStats.commits_added.length + todayStats.commits_deleted.length;
+
+  if (isNowTimeAfterDailyEmails && extendedConfigs.configs.settings.per_day_emails.email_daily_summary && !alreadySentTodaySummaryEmail && totalTodayChanges > 0) {
     updateGASProperty(GAS_PROPERTIES_ENUM.last_daily_email_sent_date, extendedConfigs.today_date);
-    const dailySummaryEmail = getDailySummaryEmail(userEmail, getTodayStats(), extendedConfigs.today_date);
+    const dailySummaryEmail = getDailySummaryEmail(userEmail, todayStats, extendedConfigs.today_date);
     sendEmail(dailySummaryEmail);
     clearTodayEvents();
   }


### PR DESCRIPTION
## Linear

- [fix error where we send email with stats even for days with 0 changes](https://linear.app/lucasvtiradentes/issue/LVTA-154/fix-error-where-we-send-email-with-stats-even-for-days-with-0-changes)

## Description

Fixes an issue where the daily summary email was being sent even when there were 0 changes for the day. Now checks if there are any actual changes before sending the email notification.

## Commits

6c63fbd chore: add changeset for daily summary email fix
4e08c4c fix: prevent sending daily summary email when there are no changes
